### PR TITLE
Fix EXC_BAD_ACCESS crash when backgrounding app

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -514,6 +514,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   if (_webViewKey != nil) {
     NSMutableDictionary *sharedRNCWebViewDictionary = [[RNCWebViewMapManager sharedManager] sharedRNCWebViewDictionary];
     sharedRNCWebViewDictionary[_webViewKey] = nil;
+    [self removeWKWebViewFromSuperView:self];
   }
 
   [super removeFromSuperview];


### PR DESCRIPTION
When we removed RNCWebView from its super view, if we were reusing the WKWebView, we previously weren't removing its references (via the observer) to the RNCWebView, and that caused an EXC_BAD_ACCESS crash when navigating away from the WebView, backgrounding the app, foregrounding the app, and navigating back to the WebView. This PR fixes the bug by properly removing references to RNCWebView when it gets removed from its super view.