### PR TITLE
fix EXC_BAD_ACCESS during remount situations

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -514,9 +514,14 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
   }
   
   if (_webViewKey != nil) {
-    NSMutableDictionary *sharedRNCWebViewDictionary = [[RNCWebViewMapManager sharedManager] sharedRNCWebViewDictionary];
-    sharedRNCWebViewDictionary[_webViewKey] = nil;
-    [self removeWKWebViewFromSuperView:self];
+    NSMutableDictionary *sharedRNCWebViewDictionary= [[RNCWebViewMapManager sharedManager] sharedRNCWebViewDictionary];
+    RNCWebView *rncWebView = sharedRNCWebViewDictionary[_webViewKey];
+      
+    // When this view is being unmounted, only remove the WKWebView from the superview
+    // if this RNCWebView is the "active" view.
+    if (rncWebView == self) {
+      [self removeWKWebViewFromSuperView:self];
+    }
   }
 
   [super removeFromSuperview];
@@ -543,6 +548,8 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 {
   // If _webView is getting added to a new super view, we need to first both remove it from the old
   // superview and also remove the observer which can reference the old super view.
+  NSMutableDictionary *sharedRNCWebViewDictionary = [[RNCWebViewMapManager sharedManager] sharedRNCWebViewDictionary];
+  sharedRNCWebViewDictionary[_webViewKey] = nil;
   [_webView removeObserver:webViewObserver forKeyPath:@"estimatedProgress"];
   [_webView removeFromSuperview];
 }


### PR DESCRIPTION
There are some specific edge cases where a crash currently happens
1) Let's say RNCWebview A is mounted on the screen.
2) RNCWebview B starts to mount (while A is still mounted) with the same webview key
3) RNCWebview B removes the WKWebview from A and attaches it to itself
4) RNCWebview A starts to unmount, and upon unmounting tries to remove WKWebview A from itself. Since RNCWebview B already did this step from (3), this causes a crash.

Here we only remove the view if the currently "set" RNCWebview inside the shared dict (where we keep track of the active view for a key) is self