### PR TITLE
fix segfault with webview remount

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -429,15 +429,14 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 #else
       _webView = [[RNCWKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];
 #endif // !TARGET_OS_OSX
-        
-        if (_webView != nil && _webViewKey != nil) {
-          sharedWKWebViewDictionary[_webViewKey] = _webView;
-          NSMutableDictionary *sharedRNCWebViewDictionary= [[RNCWebViewMapManager sharedManager] sharedRNCWebViewDictionary];
-          sharedRNCWebViewDictionary[_webViewKey] = self;
-        }
-    } else if (_webViewKey != nil) {
+    }
+      
+    if (_webViewKey != nil) {
         NSMutableDictionary *sharedRNCWebViewDictionary= [[RNCWebViewMapManager sharedManager] sharedRNCWebViewDictionary];
         sharedRNCWebViewDictionary[_webViewKey] = self;
+        if (_webView != nil) {
+            sharedWKWebViewDictionary[_webViewKey] = _webView;
+        }
     }
     
     [self setBackgroundColor: _savedBackgroundColor];


### PR DESCRIPTION
We originally forgot to re-insert the RNCWebview into the dict on remount. This was hard to track down because the stack trace I was getting was completely irrelevant.