### PR TITLE
fix hardware switch bug

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1372,14 +1372,14 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     if (initialSetup) {
         scr = [NSString stringWithFormat:@"var s=new Audio('%@');s.id='wkwebviewAudio';s.controls=false;s.loop=true;s.play();document.body.appendChild(s);true", mp3Str];
     } else {
-        scr = [NSString stringWithFormat:@"var s=document.getElementById('wkwebviewAudio');s.src=null;s.parentNode.removeChild(s);s=null;s=new Audio('%@');s.id='wkwebviewAudio';s.controls=false;s.loop=true;s.play();document.body.appendChild(s);true", mp3Str];
+        scr = [NSString stringWithFormat:@"document.getElementById('wkwebviewAudio').muted=false", mp3Str];
     }
     [self evaluateJS: scr thenCall: nil];
 }
 
 -(void)disableIgnoreSilentSwitch
 {
-    [self evaluateJS: @"document.getElementById('wkwebviewAudio').src=null;true" thenCall: nil];
+    [self evaluateJS: @"document.getElementById('wkwebviewAudio').muted=true;" thenCall: nil];
 }
 
 -(void)appDidBecomeActive

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -90,6 +90,7 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(ignoreSilentHardwareSwitch, BOOL)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)


### PR DESCRIPTION
This is a funny bug.

It seems like the original author didn't expose this property (I think they just forgot). I updated the JS code here with the updated stackoverflow post where the patch originally came from.

https://stackoverflow.com/questions/56460362/how-to-force-wkwebview-to-ignore-hardware-silent-switch-on-ios

I will make a PR upstream as well 😆 

