### PR TITLE
[android] allow webview inspection on debuggable build

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -7,6 +7,7 @@ import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -208,8 +209,10 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
     setMixedContentMode(wrapper, "never");
 
+    boolean isDebug = ((reactContext.getApplicationInfo().flags &
+      ApplicationInfo.FLAG_DEBUGGABLE) != 0);
 
-    if (ReactBuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    if (isDebug && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
       WebView.setWebContentsDebuggingEnabled(true);
     }
 


### PR DESCRIPTION
This was using `ReactBuildConfig.DEBUG` which is always false unless you aren't using a 'release' version of the react-native android library `ReactAndroid`. I am not really sure why `ReactBuildConfig`  was being checked at all. 

Checking if the application is debuggable makes more sense to me.