### PR TITLE
make injectJavaScriptWithWebViewKey return a promise

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -189,7 +189,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       RNCWebViewManager.InternalWebView webView = (RNCWebViewManager.InternalWebView) RNCWebViewMapManager.INSTANCE.getInternalWebViewMap().get(webViewKey);
       if (webView != null) {
         webView.evaluateJavascriptWithFallback(script);
-        promise.resolve();
+        promise.resolve(null);
       } else {
         promise.reject("err", "Failed to inject javascript with webViewKey: " + webViewKey + ". WebView is null.");
       }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -189,9 +189,9 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       RNCWebViewManager.InternalWebView webView = (RNCWebViewManager.InternalWebView) RNCWebViewMapManager.INSTANCE.getInternalWebViewMap().get(webViewKey);
       if (webView != null) {
         webView.evaluateJavascriptWithFallback(script);
-        promise.resolve();
+        promise.resolve(null);
       } else {
-        promise.reject("Failed to inject javascript with webViewKey: " + webViewKey + ". WebView is null.");
+        promise.reject("err", "Failed to inject javascript with webViewKey: " + webViewKey + ". WebView is null.");
       }
     });
   }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -189,7 +189,7 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
       RNCWebViewManager.InternalWebView webView = (RNCWebViewManager.InternalWebView) RNCWebViewMapManager.INSTANCE.getInternalWebViewMap().get(webViewKey);
       if (webView != null) {
         webView.evaluateJavascriptWithFallback(script);
-        promise.resolve(null);
+        promise.resolve();
       } else {
         promise.reject("err", "Failed to inject javascript with webViewKey: " + webViewKey + ". WebView is null.");
       }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewModule.java
@@ -184,13 +184,14 @@ public class RNCWebViewModule extends ReactContextBaseJavaModule implements Acti
   }
 
   @ReactMethod
-  public void injectJavaScriptWithWebViewKey(final String webViewKey, final String script) {
+  public void injectJavaScriptWithWebViewKey(final String webViewKey, final String script, final Promise promise) {
     UiThreadUtil.runOnUiThread(() -> {
       RNCWebViewManager.InternalWebView webView = (RNCWebViewManager.InternalWebView) RNCWebViewMapManager.INSTANCE.getInternalWebViewMap().get(webViewKey);
       if (webView != null) {
         webView.evaluateJavascriptWithFallback(script);
+        promise.resolve();
       } else {
-        FLog.w(TAG, "Failed to inject javascript with webViewKey: " + webViewKey + ". WebView is null.");
+        promise.reject("Failed to inject javascript with webViewKey: " + webViewKey + ". WebView is null.");
       }
     });
   }

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -212,9 +212,9 @@ RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey
 
     if (wkWebView != nil) {
       [wkWebView evaluateJavaScript:script completionHandler:nil];
-      resolve();
+      resolve(nil);
     } else {
-      reject(@"Failed to inject JavaScript. WKWebView for webViewKey is nil");
+      reject("@err", @"Failed to inject JavaScript. WKWebView for webViewKey is nil", nil);
     }
   }];
 }

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -212,7 +212,7 @@ RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey
 
     if (wkWebView != nil) {
       [wkWebView evaluateJavaScript:script completionHandler:nil];
-      resolve();
+      resolve(nil);
     } else {
       reject(
         @"err",

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -214,7 +214,11 @@ RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey
       [wkWebView evaluateJavaScript:script completionHandler:nil];
       resolve(nil);
     } else {
-      reject(@"err", @"Failed to inject JavaScript. WKWebView for webViewKey is nil", nil);
+      reject(
+        @"err",
+        [NSString stringWithFormat:@"Failed to inject JavaScript with webViewKey: %@. WKWebView is nil", webViewKey],
+        nil
+      );
     }
   }];
 }

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -212,7 +212,7 @@ RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey
 
     if (wkWebView != nil) {
       [wkWebView evaluateJavaScript:script completionHandler:nil];
-      resolve(nil);
+      resolve();
     } else {
       reject(
         @"err",

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -201,7 +201,10 @@ RCT_EXPORT_METHOD(injectJavaScript:(nonnull NSNumber *)reactTag script:(NSString
   }];
 }
 
-RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey script:(NSString *)script)
+RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey
+                  script:(NSString *)script
+                  resolve:(RCTPromiseResolveBlock) resolve
+                  reject: (RCTPromiseRejectBlock)reject)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, __unused NSDictionary<NSNumber *, RNCWebView *> *viewRegistry) {
     NSMutableDictionary *sharedWKWebViewDictionary = [[RNCWKWebViewMapManager sharedManager] sharedWKWebViewDictionary];
@@ -209,8 +212,9 @@ RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey 
 
     if (wkWebView != nil) {
       [wkWebView evaluateJavaScript:script completionHandler:nil];
+      resolve();
     } else {
-      RCTLogError(@"Failed to inject JavaScript. WKWebView for webViewKey is nil");
+      reject(@"Failed to inject JavaScript. WKWebView for webViewKey is nil");
     }
   }];
 }

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -214,7 +214,7 @@ RCT_EXPORT_METHOD(injectJavaScriptWithWebViewKey:(nonnull NSString *)webViewKey
       [wkWebView evaluateJavaScript:script completionHandler:nil];
       resolve(nil);
     } else {
-      reject("@err", @"Failed to inject JavaScript. WKWebView for webViewKey is nil", nil);
+      reject(@"err", @"Failed to inject JavaScript. WKWebView for webViewKey is nil", nil);
     }
   }];
 }

--- a/lib/injectJavaScriptWithWebViewKey.android.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.android.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): void;
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.android.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.android.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.android.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null>;
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<void>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.android.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,wBAA8B,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEvH"}

--- a/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,wBAA8B,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEvH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}

--- a/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC,CAExG"}

--- a/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.android.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,QAExF"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.android.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.android.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}

--- a/lib/injectJavaScriptWithWebViewKey.android.js
+++ b/lib/injectJavaScriptWithWebViewKey.android.js
@@ -1,4 +1,4 @@
 import { NativeModules } from 'react-native';
 export default function injectJavaScriptWithWebViewKey(webViewKey, script) {
-    NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
+    return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/lib/injectJavaScriptWithWebViewKey.android.js
+++ b/lib/injectJavaScriptWithWebViewKey.android.js
@@ -1,4 +1,44 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 import { NativeModules } from 'react-native';
 export default function injectJavaScriptWithWebViewKey(webViewKey, script) {
-    return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/, NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script)];
+        });
+    });
 }

--- a/lib/injectJavaScriptWithWebViewKey.android.js
+++ b/lib/injectJavaScriptWithWebViewKey.android.js
@@ -1,44 +1,4 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 import { NativeModules } from 'react-native';
 export default function injectJavaScriptWithWebViewKey(webViewKey, script) {
-    return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            return [2 /*return*/, NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script)];
-        });
-    });
+    return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/lib/injectJavaScriptWithWebViewKey.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null>;
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): void;
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGrH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,IAAI,CAAC,CAG5G"}

--- a/lib/injectJavaScriptWithWebViewKey.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGrH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,wBAA8B,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAG3H"}

--- a/lib/injectJavaScriptWithWebViewKey.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,QAE1F"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGrH"}

--- a/lib/injectJavaScriptWithWebViewKey.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,wBAA8B,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAG3H"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAK,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGrH"}

--- a/lib/injectJavaScriptWithWebViewKey.ios.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.ios.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): void;
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.ios.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.ios.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.ios.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null>;
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<void>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.ios.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,wBAA8B,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEvH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}

--- a/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,QAExF"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}

--- a/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,wBAA8B,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEvH"}

--- a/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.ios.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAEjH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.ios.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.ios.tsx"],"names":[],"mappings":"AAEA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,UAAU,EAAE,MAAM,EAAE,MAAM,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC,CAExG"}

--- a/lib/injectJavaScriptWithWebViewKey.ios.js
+++ b/lib/injectJavaScriptWithWebViewKey.ios.js
@@ -1,44 +1,4 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 import { NativeModules } from 'react-native';
 export default function injectJavaScriptWithWebViewKey(webViewKey, script) {
-    return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            return [2 /*return*/, NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script)];
-        });
-    });
+    return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/lib/injectJavaScriptWithWebViewKey.ios.js
+++ b/lib/injectJavaScriptWithWebViewKey.ios.js
@@ -1,4 +1,44 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 import { NativeModules } from 'react-native';
 export default function injectJavaScriptWithWebViewKey(webViewKey, script) {
-    return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            return [2 /*return*/, NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script)];
+        });
+    });
 }

--- a/lib/injectJavaScriptWithWebViewKey.ios.js
+++ b/lib/injectJavaScriptWithWebViewKey.ios.js
@@ -1,4 +1,4 @@
 import { NativeModules } from 'react-native';
 export default function injectJavaScriptWithWebViewKey(webViewKey, script) {
-    NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
+    return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/lib/injectJavaScriptWithWebViewKey.js
+++ b/lib/injectJavaScriptWithWebViewKey.js
@@ -1,3 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
     // no-op. This should get overwritten by platform-specific implementations
+    return Promise.resolve(null);
 }

--- a/lib/injectJavaScriptWithWebViewKey.js
+++ b/lib/injectJavaScriptWithWebViewKey.js
@@ -1,44 +1,4 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
-    return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            // no-op. This should get overwritten by platform-specific implementations
-            return [2 /*return*/, Promise.resolve(null)];
-        });
-    });
+    // no-op. This should get overwritten by platform-specific implementations
+    return Promise.resolve(null);
 }

--- a/lib/injectJavaScriptWithWebViewKey.js
+++ b/lib/injectJavaScriptWithWebViewKey.js
@@ -1,4 +1,44 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
-    // no-op. This should get overwritten by platform-specific implementations
-    return Promise.resolve(null);
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            // no-op. This should get overwritten by platform-specific implementations
+            return [2 /*return*/, Promise.resolve(null)];
+        });
+    });
 }

--- a/lib/injectJavaScriptWithWebViewKey.js
+++ b/lib/injectJavaScriptWithWebViewKey.js
@@ -1,4 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
     // no-op. This should get overwritten by platform-specific implementations
-    return Promise.resolve(null);
+    return Promise.resolve();
 }

--- a/lib/injectJavaScriptWithWebViewKey.macos.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.macos.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null>;
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.macos.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.macos.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.macos.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): void;
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.macos.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,QAE1F"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}

--- a/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,wBAA8B,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGzH"}

--- a/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC,CAG1G"}

--- a/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.macos.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,wBAA8B,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGzH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.macos.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.macos.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}

--- a/lib/injectJavaScriptWithWebViewKey.macos.js
+++ b/lib/injectJavaScriptWithWebViewKey.macos.js
@@ -1,44 +1,4 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
-    return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            // no-op
-            return [2 /*return*/, Promise.resolve(null)];
-        });
-    });
+    // no-op
+    return Promise.resolve(null);
 }

--- a/lib/injectJavaScriptWithWebViewKey.macos.js
+++ b/lib/injectJavaScriptWithWebViewKey.macos.js
@@ -1,4 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
     // no-op
-    return Promise.resolve(null);
+    return Promise.resolve();
 }

--- a/lib/injectJavaScriptWithWebViewKey.macos.js
+++ b/lib/injectJavaScriptWithWebViewKey.macos.js
@@ -1,3 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
     // no-op
+    return Promise.resolve(null);
 }

--- a/lib/injectJavaScriptWithWebViewKey.macos.js
+++ b/lib/injectJavaScriptWithWebViewKey.macos.js
@@ -1,4 +1,44 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
-    // no-op
-    return Promise.resolve(null);
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            // no-op
+            return [2 /*return*/, Promise.resolve(null)];
+        });
+    });
 }

--- a/lib/injectJavaScriptWithWebViewKey.windows.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.windows.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null>;
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.windows.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.windows.d.ts
+++ b/lib/injectJavaScriptWithWebViewKey.windows.d.ts
@@ -1,2 +1,2 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): void;
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null>;
 //# sourceMappingURL=injectJavaScriptWithWebViewKey.windows.d.ts.map

--- a/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,IAAI,CAAC,CAG1G"}

--- a/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,wBAA8B,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGzH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}

--- a/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,wBAA8B,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGzH"}

--- a/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
+++ b/lib/injectJavaScriptWithWebViewKey.windows.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,QAE1F"}
+{"version":3,"file":"injectJavaScriptWithWebViewKey.windows.d.ts","sourceRoot":"","sources":["../src/injectJavaScriptWithWebViewKey.windows.tsx"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,UAAU,8BAA8B,CAAC,WAAW,EAAE,MAAM,EAAE,OAAO,EAAE,MAAM,GAAG,OAAO,CAAC,MAAM,GAAG,IAAI,CAAC,CAGnH"}

--- a/lib/injectJavaScriptWithWebViewKey.windows.js
+++ b/lib/injectJavaScriptWithWebViewKey.windows.js
@@ -1,44 +1,4 @@
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
-    return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            // no-op
-            return [2 /*return*/, Promise.resolve(null)];
-        });
-    });
+    // no-op
+    return Promise.resolve(null);
 }

--- a/lib/injectJavaScriptWithWebViewKey.windows.js
+++ b/lib/injectJavaScriptWithWebViewKey.windows.js
@@ -1,4 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
     // no-op
-    return Promise.resolve(null);
+    return Promise.resolve();
 }

--- a/lib/injectJavaScriptWithWebViewKey.windows.js
+++ b/lib/injectJavaScriptWithWebViewKey.windows.js
@@ -1,3 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
     // no-op
+    return Promise.resolve(null);
 }

--- a/lib/injectJavaScriptWithWebViewKey.windows.js
+++ b/lib/injectJavaScriptWithWebViewKey.windows.js
@@ -1,4 +1,44 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 export default function injectJavaScriptWithWebViewKey(_webViewKey, _script) {
-    // no-op
-    return Promise.resolve(null);
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            // no-op
+            return [2 /*return*/, Promise.resolve(null)];
+        });
+    });
 }

--- a/src/injectJavaScriptWithWebViewKey.android.tsx
+++ b/src/injectJavaScriptWithWebViewKey.android.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default async function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
   return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.android.tsx
+++ b/src/injectJavaScriptWithWebViewKey.android.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<void> {
   return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.android.tsx
+++ b/src/injectJavaScriptWithWebViewKey.android.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+export default async function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
   return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.android.tsx
+++ b/src/injectJavaScriptWithWebViewKey.android.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string) {
-  NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+  return NativeModules.RNCWebView.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.ios.tsx
+++ b/src/injectJavaScriptWithWebViewKey.ios.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+export default async function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
   return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.ios.tsx
+++ b/src/injectJavaScriptWithWebViewKey.ios.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default async function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
   return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.ios.tsx
+++ b/src/injectJavaScriptWithWebViewKey.ios.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<void> {
   return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.ios.tsx
+++ b/src/injectJavaScriptWithWebViewKey.ios.tsx
@@ -1,5 +1,5 @@
 import { NativeModules } from 'react-native';
 
-export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string) {
-  NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
+export default function injectJavaScriptWithWebViewKey(webViewKey: string, script: string): Promise<string | null> {
+  return NativeModules.RNCWebViewManager.injectJavaScriptWithWebViewKey(webViewKey, script);
 }

--- a/src/injectJavaScriptWithWebViewKey.macos.tsx
+++ b/src/injectJavaScriptWithWebViewKey.macos.tsx
@@ -1,4 +1,4 @@
-export default async function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
   // no-op
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.macos.tsx
+++ b/src/injectJavaScriptWithWebViewKey.macos.tsx
@@ -1,4 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void> {
   // no-op
-  return Promise.resolve(null);
+  return Promise.resolve();
 }

--- a/src/injectJavaScriptWithWebViewKey.macos.tsx
+++ b/src/injectJavaScriptWithWebViewKey.macos.tsx
@@ -1,4 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void> {
   // no-op
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.macos.tsx
+++ b/src/injectJavaScriptWithWebViewKey.macos.tsx
@@ -1,3 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string) {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
   // no-op
+  return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.macos.tsx
+++ b/src/injectJavaScriptWithWebViewKey.macos.tsx
@@ -1,4 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
+export default async function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
   // no-op
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.tsx
+++ b/src/injectJavaScriptWithWebViewKey.tsx
@@ -1,4 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<string | null> {
+export default async function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<string | null> {
   // no-op. This should get overwritten by platform-specific implementations
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.tsx
+++ b/src/injectJavaScriptWithWebViewKey.tsx
@@ -1,4 +1,4 @@
-export default async function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<string | null> {
   // no-op. This should get overwritten by platform-specific implementations
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.tsx
+++ b/src/injectJavaScriptWithWebViewKey.tsx
@@ -1,4 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<void> {
   // no-op. This should get overwritten by platform-specific implementations
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.tsx
+++ b/src/injectJavaScriptWithWebViewKey.tsx
@@ -1,4 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<void> {
   // no-op. This should get overwritten by platform-specific implementations
-  return Promise.resolve(null);
+  return Promise.resolve();
 }

--- a/src/injectJavaScriptWithWebViewKey.tsx
+++ b/src/injectJavaScriptWithWebViewKey.tsx
@@ -1,3 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string) {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string, ): Promise<string | null> {
   // no-op. This should get overwritten by platform-specific implementations
+  return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.windows.tsx
+++ b/src/injectJavaScriptWithWebViewKey.windows.tsx
@@ -1,4 +1,4 @@
-export default async function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
   // no-op
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.windows.tsx
+++ b/src/injectJavaScriptWithWebViewKey.windows.tsx
@@ -1,4 +1,4 @@
 export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void> {
   // no-op
-  return Promise.resolve(null);
+  return Promise.resolve();
 }

--- a/src/injectJavaScriptWithWebViewKey.windows.tsx
+++ b/src/injectJavaScriptWithWebViewKey.windows.tsx
@@ -1,4 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<void> {
   // no-op
   return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.windows.tsx
+++ b/src/injectJavaScriptWithWebViewKey.windows.tsx
@@ -1,3 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string) {
+export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
   // no-op
+  return Promise.resolve(null);
 }

--- a/src/injectJavaScriptWithWebViewKey.windows.tsx
+++ b/src/injectJavaScriptWithWebViewKey.windows.tsx
@@ -1,4 +1,4 @@
-export default function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
+export default async function injectJavaScriptWithWebViewKey(_webViewKey: string, _script: string): Promise<string | null> {
   // no-op
   return Promise.resolve(null);
 }


### PR DESCRIPTION
When injecting javascript fails because there's no WebView for the WebView key, we want to ability to log the error from JavaScript. This PR updates `injectJavaScriptWithWebViewKey` to return a promise. When the promise is rejected, the JS part of the app can capture and log the error message.

I tested this by injecting javascript with a WebView key when there was no WebView in the Discord app, and I verified that the error message in Java / Objective-C appeared in the promise rejection in JS (verified via console logs).