### PR TITLE
fix bug where navigation delegate stops working after reusing WKWebView

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -441,7 +441,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     
     [self setBackgroundColor: _savedBackgroundColor];
     
-    if (!reusedWebViewInstance) {
+    //if (!reusedWebViewInstance) {
 #if !TARGET_OS_OSX
       _webView.scrollView.delegate = self;
 #endif // !TARGET_OS_OSX
@@ -473,7 +473,7 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
         _webView.scrollView.automaticallyAdjustsScrollIndicatorInsets = _savedAutomaticallyAdjustsScrollIndicatorInsets;
       }
 #endif
-    }
+    //}
     
     // We have to remove the old observer via removeWKWebViewFromSuperView when reusing the WKWebView instance,
     // so whether we're reusing the instance or not, we always have to add the observer that references the new

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -441,39 +441,37 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
     
     [self setBackgroundColor: _savedBackgroundColor];
     
-    //if (!reusedWebViewInstance) {
 #if !TARGET_OS_OSX
-      _webView.scrollView.delegate = self;
+    _webView.scrollView.delegate = self;
 #endif // !TARGET_OS_OSX
-      _webView.UIDelegate = self;
-      _webView.navigationDelegate = self;
+    _webView.UIDelegate = self;
+    _webView.navigationDelegate = self;
 #if !TARGET_OS_OSX
-      if (_pullToRefreshEnabled) {
-          [self addPullToRefreshControl];
-      }
-      _webView.scrollView.scrollEnabled = _scrollEnabled;
-      _webView.scrollView.pagingEnabled = _pagingEnabled;
-        //For UIRefreshControl to work correctly, the bounces should always be true
-      _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces;
-      _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
-      _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
-      _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
+    if (_pullToRefreshEnabled) {
+        [self addPullToRefreshControl];
+    }
+    _webView.scrollView.scrollEnabled = _scrollEnabled;
+    _webView.scrollView.pagingEnabled = _pagingEnabled;
+      //For UIRefreshControl to work correctly, the bounces should always be true
+    _webView.scrollView.bounces = _pullToRefreshEnabled || _bounces;
+    _webView.scrollView.showsHorizontalScrollIndicator = _showsHorizontalScrollIndicator;
+    _webView.scrollView.showsVerticalScrollIndicator = _showsVerticalScrollIndicator;
+    _webView.scrollView.directionalLockEnabled = _directionalLockEnabled;
 #endif // !TARGET_OS_OSX
-      _webView.allowsLinkPreview = _allowsLinkPreview;
-      _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
+    _webView.allowsLinkPreview = _allowsLinkPreview;
+    _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 
-      _webView.customUserAgent = _userAgent;
+    _webView.customUserAgent = _userAgent;
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
-      if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
-        _webView.scrollView.contentInsetAdjustmentBehavior = _savedContentInsetAdjustmentBehavior;
-      }
+    if ([_webView.scrollView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
+      _webView.scrollView.contentInsetAdjustmentBehavior = _savedContentInsetAdjustmentBehavior;
+    }
 #endif
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
-      if (@available(iOS 13.0, *)) {
-        _webView.scrollView.automaticallyAdjustsScrollIndicatorInsets = _savedAutomaticallyAdjustsScrollIndicatorInsets;
-      }
+    if (@available(iOS 13.0, *)) {
+      _webView.scrollView.automaticallyAdjustsScrollIndicatorInsets = _savedAutomaticallyAdjustsScrollIndicatorInsets;
+    }
 #endif
-    //}
     
     // We have to remove the old observer via removeWKWebViewFromSuperView when reusing the WKWebView instance,
     // so whether we're reusing the instance or not, we always have to add the observer that references the new


### PR DESCRIPTION
I was trying to make a button-click in the web page in the WebView conditionally load an iframe. Loading the iframe successfully depends on the navigation delegate as I learned from https://stackoverflow.com/questions/41250162/wkwebview-not-loading-content-from-iframe-on-a-webpage , and I realized the navigation delegate wasn't getting reconnected properly when attaching the WKWebView to a new RNCWebView. See additional context in https://github.com/react-native-webview/react-native-webview/pull/2469/files#r1026979105 .