### PR TITLE
[Android] - Use RNCWebViewContainer for setAllowsProtectedMedia

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -816,13 +816,13 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebViewContainer> {
   }
 
   @ReactProp(name = "allowsProtectedMedia")
-  public void setAllowsProtectedMedia(WebView view, boolean enabled) {
+  public void setAllowsProtectedMedia(RNCWebViewContainer view, boolean enabled) {
     // This variable is used to keep consistency
     // in case a new WebChromeClient is created
     // (eg. when mAllowsFullScreenVideo changes)
     mAllowsProtectedMedia = enabled;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        WebChromeClient client = view.getWebChromeClient();
+        WebChromeClient client = view.getWebView().getWebChromeClient();
         if (client != null && client instanceof RNCWebChromeClient) {
             ((RNCWebChromeClient) client).setAllowsProtectedMedia(enabled);
         }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -822,10 +822,12 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebViewContainer> {
     // (eg. when mAllowsFullScreenVideo changes)
     mAllowsProtectedMedia = enabled;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        WebChromeClient client = view.getWebView().getWebChromeClient();
+      view.ifHasRNCWebView((webView) -> {
+        WebChromeClient client = webView.getWebChromeClient();
         if (client != null && client instanceof RNCWebChromeClient) {
-            ((RNCWebChromeClient) client).setAllowsProtectedMedia(enabled);
+          ((RNCWebChromeClient) client).setAllowsProtectedMedia(enabled);
         }
+      });
     }
   }
 


### PR DESCRIPTION
This PR patches usage of the Android-only `allowsProtectedMedia` prop.
Asana task: https://app.asana.com/0/1206944884049668/1207310688340866/f

Prior to this patch, using the `allowsProtectedMedia` prop would cause a crash with the following error

> IllegalArgumentException
method com.reactnativecommunity.webview.RNCWebViewManager.setAllowsProtectedMedia argument 1 has type android.webkit.WebView, got com.reactnativecommunity.webview.b

Confirmed with this change Android can play Amazon Music DRM-protected content
<img width="441" alt="Screenshot 2024-05-13 at 8 12 31 PM" src="https://github.com/discord/react-native-webview/assets/4811753/fffe171d-4457-4820-a169-c9787845fe8a">

I'm not sure if this makes sense to merge into `11.18.1-discord-2` or if we should take a different approach, but... this diff looks like it solves the core problem.