### PR TITLE
[android] Guard setAssetLoaderConfig reload for keyed WebViews

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -485,7 +485,10 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebViewContainer> {
     WebViewAssetLoader assetLoader = builder.build();
     view.ifHasRNCWebView(webView -> {
       webView.setWebViewAssetLoader(assetLoader);
-      if (webView.getUrl() != null) {
+      // Skip reload for keyed (reparentable) WebViews — the config values
+      // are unchanged across reparent cycles, so reloading would destroy
+      // active iframe sessions. Matches the setSource guard at line 667.
+      if (webView.getUrl() != null && webView.webViewKey == null) {
         webView.reload();
       }
     });


### PR DESCRIPTION
Prevent reload of keyed Webviews to fix an Activities remount during the PIP->fullscreen transition. ([Asana](https://app.asana.com/1/236888843494340/project/1199167684846005/task/1213392170632946?focus=true))

## Background

Embedded Activities are an Apps feature that launches web content in an iframe. (Examples: Wordle, Watch Together.) Activities can transition from fullscreen to a picture-in-picture (PIP) mode and back. We got multiple reports that some time ago (perhaps months) the Activities iframe began remounting when transitioning from PiP (Picture-in-Picture) mode to full screen. Remounting is destructive for embedded activities because it reloads the iframe content, breaking active sessions, websocket connections, and application state.

When I did some investigation using the Android simulator, I could repro the Activity closing unexpectedly during the fullscreen->PIP transition. I wasn't actually able to get as far as the PIP->fullscreen transition. The root cause seems to be: When a WebView with a webViewKey is reparented (e.g. during PiP to fullscreen transitions in embedded activities), setAssetLoaderConfig fires with identical config values on the reclaimed WebView. The unconditional reload() destroys the active iframe session.

[Andrew did some LLM-assisted investigation](https://www.notion.so/discordapp/Android-Embedded-Activities-PiP-Full-iframe-Remount-Investigation-310f46fd48aa8110a505ca80e86cf360) that recommended a JS-side guard for this issue, or a native code guard.

I actually [tried solving this with a JS-side guard first](https://github.com/discord/discord/pull/267838) (singleton on `EmbeddedActivitiesNativeManager`) but it didn't seem to work because the React layer still sees this transition as a new component instance mounting and sends all props to the native side. This causes a native reload. 

So instead, here's the native-side fix: Add a webViewKey null-check before reload(), matching the existing guard in setSource (line 667). Keyed WebViews are managed by the reparenting system and should never reload due to redundant config prop updates.

## Testing

I locally modified package.json to point react-native-webview` at my commit, rebuilt, and tested with the Android simulator. I was able to take both Wordle and Watch Together back and forth between PIP and fullscreen without loss of context.

## Process Questions

I've never contributed to this fork before. What's our process for merging and shipping changes here?